### PR TITLE
Bug bash

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,10 +50,6 @@
   name = "google.golang.org/api"
 
 [[constraint]]
-  name = "k8s.io/helm"
-  version = "2.9.0"
-
-[[constraint]]
   name = "helm.sh/helm"
   version = "3.0.0-beta.3"
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-helm-gcs has a new owner [@hayorov](https://github.com/hayorov) and **more maintainers WANTED**, please [contact me](mailto:i@hayorov.ru) for details.
-
 # helm-gcs for Helm 3
 
-`helm-gcs` is a [helm](https://github.com/kubernetes/helm) plugin that allows you to manage private helm repositories on [Google Cloud Storage](https://cloud.google.com/storage/) aka buckets.
+`helm-gcs` is a [helm](https://github.com/helm/helm) plugin that allows you to manage private helm repositories on [Google Cloud Storage](https://cloud.google.com/storage/) aka buckets.
+
+### NOTICE
+
+The plugin hosted in this repo [hd-rk/helm-gcs](https://github.com/hd-rk/helm-gcs) has been patched to work with Helm 3.
+The minimum version is `0.3.0`.
+
+For Helm 2 compatible plugin, please use the original plugin [hayorov/helm-gcs](https://github.com/hayorov/helm-gcs)
 
 ## Installation
-
-Helm 3 is supported in helm-gcs version 0.3.0 and up.
 
 Install the stable version:
 ```shell

--- a/cmd/helm-gcs/cmd/rm.go
+++ b/cmd/helm-gcs/cmd/rm.go
@@ -25,7 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var flagVersion string
+var (
+	flagVersion string
+	flagRmRetry bool
+)
 
 var rmCmd = &cobra.Command{
 	Use:     "rm [chart] [repository]",
@@ -40,11 +43,12 @@ If no specific version is given, all versions will be removed.`,
 		if err != nil {
 			return err
 		}
-		return r.RemoveChart(chart, flagVersion)
+		return r.RemoveChart(chart, flagVersion, flagRmRetry)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(rmCmd)
 	rmCmd.Flags().StringVarP(&flagVersion, "version", "v", "", "version of the chart to remove")
+	rmCmd.Flags().BoolVar(&flagRmRetry, "retry", false, "retry if the index changed")
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -148,10 +148,11 @@ func (r Repo) PushChart(chartpath string, force, retry bool, public bool, public
 
 // RemoveChart removes a chart from the repository
 // If version is empty, all version will be deleted.
-func (r Repo) RemoveChart(name, version string) error {
+func (r Repo) RemoveChart(name, version string, retry bool) error {
 	// log := logger()
 	log.Debugf("removing chart %s-%s", name, version)
 
+removeChart:
 	index, err := r.indexFile()
 	if err != nil {
 		return errors.Wrap(err, "index")
@@ -179,6 +180,10 @@ func (r Repo) RemoveChart(name, version string) error {
 	}
 
 	err = r.uploadIndexFile(index)
+	if err == ErrIndexOutOfDate && retry {
+		goto removeChart
+	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -166,7 +166,8 @@ func (r Repo) RemoveChart(name, version string) error {
 	for i, v := range vs {
 		if version == "" || version == v.Version {
 			log.Debugf("%s-%s will be deleted", name, v.Version)
-			urls = append(urls, v.URLs...)
+			chartURL := fmt.Sprintf("%s/%s-%s.tgz", r.entry.URL, name, v.Version)
+			urls = append(urls, chartURL)
 		}
 		if version == v.Version {
 			index.Entries[name] = append(vs[:i], vs[i+1:]...)


### PR DESCRIPTION
Some bug fixes after code self-inspection.

- [x] Add `--retry` flag for `remove` command as well.
- [x] Fix: `remove` should use `gs://` (instead of public https://) URL to remove charts.
- [x] Fix: update `Generated` timestamp when update `index.yaml`.
- [x] Fix: update `index.yaml` even when force push a chart with same name/version.